### PR TITLE
Import configuration

### DIFF
--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -8,7 +8,7 @@ transfer: "ln_s"
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
 output: "yaml"
-parallel_upload: 50
+parallel_upload: "50"
 columns:
     - name
     - path

--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -8,7 +8,6 @@ transfer: "ln_s"
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
 output: "yaml"
-skip: "all"
 parallel_upload: "50"
 columns:
     - name

--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -1,4 +1,14 @@
 ---
 target: "Screen:name:idr0037-vigilante-hipsci/screenA"
-include: "../../bulk.yml"
 path: "idr0037-screenA-plates.tsv"
+continue: "true"
+transfer: "ln_s"
+# Do not exclude if we are reimporting raw data from idr0034
+# exclude: "clientpath"
+checksum_algorithm: "File-Size-64"
+logprefix: "logs/"
+output: "yaml"
+parallel_upload: 50
+columns:
+    - name
+    - path

--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -8,7 +8,9 @@ transfer: "ln_s"
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
 output: "yaml"
+skip: "all"
 parallel_upload: "50"
+parallel_fileset: "4"
 columns:
     - name
     - path

--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -5,6 +5,7 @@ continue: "true"
 transfer: "ln_s"
 # Do not exclude if we are reimporting raw data from idr0034
 # exclude: "clientpath"
+l: readers.txt
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
 output: "yaml"

--- a/screenA/idr0037-screenA-bulk.yml
+++ b/screenA/idr0037-screenA-bulk.yml
@@ -10,7 +10,6 @@ logprefix: "logs/"
 output: "yaml"
 skip: "all"
 parallel_upload: "50"
-parallel_fileset: "4"
 columns:
     - name
     - path

--- a/screenA/idr0037-screenA-plates.tsv
+++ b/screenA/idr0037-screenA-plates.tsv
@@ -1,69 +1,69 @@
-experiment_1	/uod/idr/filesets/idr0037-vigilante-hipsci/images/20140424_HipSci + BJ 3000c_well_OC__2014-04-24T17_01_22-Measurement1
-experiment_10	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 10 Plate 1__2014-08-21T17_57_35-Measurement1
-experiment_11	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/Experiment 11_hikj1 qanu2 Bob huls1 funp3 vopm2 qimz1 zisa3__2014-09-03T14_08_52-Measurement1
-experiment_12	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 12 Plate 1__2014-09-12T09_49_03-Measurement1
-experiment_13	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 13 Plate 1 NM 20140924__2014-09-24T15_27_19-Measurement1
-experiment_14_plate1	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-19 HipSci Exp14_plate1__2015-06-19T10_47_41-Measurement1
-experiment_14_plate2	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-16 HipSci Exp14_plate2__2015-06-16T12_11_39-Measurement1
-experiment_14_plate3	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-19 HipSci Exp14_plate3__2015-06-19T11_49_27-Measurement1
-experiment_15	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-17 HipSci Exp 15__2014-10-17T11_01_13-Measurement1
-experiment_16	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-17 HipSci Exp 16__2014-10-17T12_17_05-Measurement1
-experiment_17	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-24 HipSci Exp 17__2014-10-24T14_59_23-Measurement1
-experiment_18	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-11-11 HipSci Exp 18__2014-11-11T15_54_46-Measurement1
-experiment_19	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-11-11 HipSci Exp 19__2014-11-11T14_42_13-Measurement1
-experiment_2	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/HipSci Experiment 2__2014-04-29T10_58_26-Measurement1
-experiment_20	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 20__2014-12-11T13_18_00-Measurement1
-experiment_21	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 21__2014-12-11T13_53_57-Measurement1
-experiment_22	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 22__2014-12-11T14_32_52-Measurement1
-experiment_23	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2015-02-19 HipSci Exp 23__2015-02-19T12_08_01-Measurement1
-experiment_24	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2015-02-27 HipSci Exp 24__2015-02-27T12_55_50-Measurement1
-experiment_25	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-02-19 HipSci Exp 25__2015-03-05T15_32_03-Measurement1
-experiment_26	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-08 HipSci Exp 26__2015-03-09T09_58_49-Measurement1
-experiment_27	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-13 HipSci Exp 27__2015-03-13T11_55_12-Measurement1
-experiment_28	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-17 HipSci 28__2015-03-17T12_08_28-Measurement1
-experiment_29	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-19 HipSci exp 29__2015-03-19T12_50_06-Measurement1
-experiment_3	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/2014-05-28_Experiment 3 HipSci Repeat Acquisition_OC__2014-05-28T11_47_10-Measurement1
-experiment_30	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-04-21- HipSci Exp30__2015-04-21T12_37_28-Measurement1
-experiment_31	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-04-29 HipSci Exp31__2015-04-29T12_42_10-Measurement1
-experiment_32	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-05-06 Hipsci Exp32__2015-05-06T12_58_06-Measurement1
-experiment_33	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-05-11 HipSci Exp33__2015-05-11T12_29_05-Measurement1
-experiment_34	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-05-22 HipSci Exp34__2015-05-22T13_13_23-Measurement1
-experiment_35	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-02 HipSci Exp35__2015-06-02T11_18_40-Measurement1
-experiment_36	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-05 HipSci Exp36__2015-06-05T14_49_35-Measurement1
-experiment_37	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-16 HipSci Exp37__2015-06-16T10_34_41-Measurement1
-experiment_38	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-16 HipSci Exp38__2015-06-16T11_29_46-Measurement1
-experiment_39	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-19 HipSci Exp 39__2015-06-19T13_04_48-Measurement1
-experiment_4	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/2014-05-19_HipSci Lines Experiment 4_OC__2014-05-19T12_35_36-Measurement2
-experiment_40	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-19 HipSci Exp 40__2015-06-25T10_59_27-Measurement1
-experiment_41	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-03 HipSci Exp 41__2015-07-03T12_21_59-Measurement1
-experiment_42	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-09 HipSci Exp 42__2015-07-09T15_07_08-Measurement1
-experiment_43	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-09 HipSci Exp 43__2015-07-09T15_52_04-Measurement1
-experiment_44	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 44__2016-02-16T16_07_20-Measurement1
-experiment_45	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 45__2016-02-16T17_20_42-Measurement1
-experiment_46	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp46__2016-03-03T12_24_01-Measurement1
-experiment_47	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 47__2016-02-24T12_13_40-Measurement1
-experiment_48	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-24 HipSci Exp 48__2016-02-24T12_58_55-Measurement1
-experiment_49	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03_Hipsci_assay_Exp49__2016-03-03T13_14_51-Measurement1
-experiment_5	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2014-05-28_Experiment 5 HipSci_OC__2014-05-28T15_07_33-Measurement1
-experiment_50	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp50__2016-03-03T14_09_29-Measurement1
-experiment_51	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp51__2016-03-03T15_14_48-Measurement1
-experiment_52	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp52__2016-03-03T15_59_09-Measurement1
-experiment_53	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp53__2016-03-03T16_41_19-Measurement1
-experiment_54	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-10 HipSci Exp54__2016-03-10T15_20_30-Measurement1
-experiment_55	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-10 HipSci Exp55__2016-03-10T16_09_19-Measurement1
-experiment_56	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-15 HipSci Exp56__2016-03-15T13_12_31-Measurement1
-experiment_57	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-17 HipSci Exp57__2016-03-17T10_37_40-Measurement1
-experiment_58	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-17 HipSci Exp58__2016-03-17T11_44_22-Measurement1
-experiment_59	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-24 HipSci Exp59__2016-03-24T13_33_15-Measurement1
-experiment_6	/uod/idr/filesets/idr0037-vigilante-hipsci/images/Experiment 6 05062014 NM__2014-06-05T10_05_19-Measurement1
-experiment_60	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-06-03 HipSci Exp60__2016-06-03T13_21_24-Measurement1
-experiment_61	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-06-03 HipSci Exp61__2016-06-03T14_17_55-Measurement1
-experiment_62	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-08 HipSci Exp 62__2016-09-08T12_25_29-Measurement1
-experiment_63	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-08 HipSci Exp 63__2016-09-13T12_36_37-Measurement1
-experiment_64	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-20 HipSci Exp 64__2016-09-20T10_53_55-Measurement1
-experiment_65	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-23 HipSci Exp 65__2016-09-23T12_51_26-Measurement1
-experiment_66	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-10-03 HipSci Exp 66__2016-10-03T11_12_03-Measurement1
-experiment_7a	/uod/idr/filesets/idr0037-vigilante-hipsci/images/HipSci Experiment 7 Plate 1 24072014__2014-07-24T09_56_40-Measurement1
-experiment_7b	/uod/idr/filesets/idr0037-vigilante-hipsci/images/HipSci Experiment 7 Plate 2 24072014__2014-07-24T11_10_20-Measurement1
-experiment_8	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/Experiment 8 Plate 2_Bob funp3 qimz1 zisa3_OC_06-08-2014__2014-08-06T10_45_42-Measurement1
-experiment_9	/uod/idr/filesets/idr0037-vigilante-hipsci/images/Experiment 9 Plate 1_Bob hikj1 qanu2 huls1 vopm2_22-08-2014_OC__2014-08-26T13_30_05-Measurement1
+experiment_1	/uod/idr/filesets/idr0037-vigilante-hipsci/images/20140424_HipSci + BJ 3000c_well_OC__2014-04-24T17_01_22-Measurement1/Images/Index.idx.xml
+experiment_10	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 10 Plate 1__2014-08-21T17_57_35-Measurement1/Images/Index.idx.xml
+experiment_11	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/Experiment 11_hikj1 qanu2 Bob huls1 funp3 vopm2 qimz1 zisa3__2014-09-03T14_08_52-Measurement1/Images/Index.idx.xml
+experiment_12	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 12 Plate 1__2014-09-12T09_49_03-Measurement1/Images/Index.idx.xml
+experiment_13	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/HipSci Experiment 13 Plate 1 NM 20140924__2014-09-24T15_27_19-Measurement1/Images/Index.idx.xml
+experiment_14_plate1	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-19 HipSci Exp14_plate1__2015-06-19T10_47_41-Measurement1/Images/Index.idx.xml
+experiment_14_plate2	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-16 HipSci Exp14_plate2__2015-06-16T12_11_39-Measurement1/Images/Index.idx.xml
+experiment_14_plate3	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-06-19 HipSci Exp14_plate3__2015-06-19T11_49_27-Measurement1/Images/Index.idx.xml
+experiment_15	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-17 HipSci Exp 15__2014-10-17T11_01_13-Measurement1/Images/Index.idx.xml
+experiment_16	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-17 HipSci Exp 16__2014-10-17T12_17_05-Measurement1/Images/Index.idx.xml
+experiment_17	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-10-24 HipSci Exp 17__2014-10-24T14_59_23-Measurement1/Images/Index.idx.xml
+experiment_18	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-11-11 HipSci Exp 18__2014-11-11T15_54_46-Measurement1/Images/Index.idx.xml
+experiment_19	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-11-11 HipSci Exp 19__2014-11-11T14_42_13-Measurement1/Images/Index.idx.xml
+experiment_2	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/HipSci Experiment 2__2014-04-29T10_58_26-Measurement1/Images/Index.idx.xml
+experiment_20	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 20__2014-12-11T13_18_00-Measurement1/Images/Index.idx.xml
+experiment_21	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 21__2014-12-11T13_53_57-Measurement1/Images/Index.idx.xml
+experiment_22	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2014-12-11 HipSci Exp 22__2014-12-11T14_32_52-Measurement1/Images/Index.idx.xml
+experiment_23	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2015-02-19 HipSci Exp 23__2015-02-19T12_08_01-Measurement1/Images/Index.idx.xml
+experiment_24	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Nathalie/2015-02-27 HipSci Exp 24__2015-02-27T12_55_50-Measurement1/Images/Index.idx.xml
+experiment_25	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-02-19 HipSci Exp 25__2015-03-05T15_32_03-Measurement1/Images/Index.idx.xml
+experiment_26	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-08 HipSci Exp 26__2015-03-09T09_58_49-Measurement1/Images/Index.idx.xml
+experiment_27	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-13 HipSci Exp 27__2015-03-13T11_55_12-Measurement1/Images/Index.idx.xml
+experiment_28	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-17 HipSci 28__2015-03-17T12_08_28-Measurement1/Images/Index.idx.xml
+experiment_29	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-03-19 HipSci exp 29__2015-03-19T12_50_06-Measurement1/Images/Index.idx.xml
+experiment_3	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/2014-05-28_Experiment 3 HipSci Repeat Acquisition_OC__2014-05-28T11_47_10-Measurement1/Images/Index.idx.xml
+experiment_30	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-04-21- HipSci Exp30__2015-04-21T12_37_28-Measurement1/Images/Index.idx.xml
+experiment_31	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-04-29 HipSci Exp31__2015-04-29T12_42_10-Measurement1/Images/Index.idx.xml
+experiment_32	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Ruta/2015-05-06 Hipsci Exp32__2015-05-06T12_58_06-Measurement1/Images/Index.idx.xml
+experiment_33	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-05-11 HipSci Exp33__2015-05-11T12_29_05-Measurement1/Images/Index.idx.xml
+experiment_34	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-05-22 HipSci Exp34__2015-05-22T13_13_23-Measurement1/Images/Index.idx.xml
+experiment_35	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-02 HipSci Exp35__2015-06-02T11_18_40-Measurement1/Images/Index.idx.xml
+experiment_36	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-05 HipSci Exp36__2015-06-05T14_49_35-Measurement1/Images/Index.idx.xml
+experiment_37	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-16 HipSci Exp37__2015-06-16T10_34_41-Measurement1/Images/Index.idx.xml
+experiment_38	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-16 HipSci Exp38__2015-06-16T11_29_46-Measurement1/Images/Index.idx.xml
+experiment_39	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-19 HipSci Exp 39__2015-06-19T13_04_48-Measurement1/Images/Index.idx.xml
+experiment_4	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/2014-05-19_HipSci Lines Experiment 4_OC__2014-05-19T12_35_36-Measurement2/Images/Index.idx.xml
+experiment_40	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-06-19 HipSci Exp 40__2015-06-25T10_59_27-Measurement1/Images/Index.idx.xml
+experiment_41	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-03 HipSci Exp 41__2015-07-03T12_21_59-Measurement1/Images/Index.idx.xml
+experiment_42	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-09 HipSci Exp 42__2015-07-09T15_07_08-Measurement1/Images/Index.idx.xml
+experiment_43	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2015-07-09 HipSci Exp 43__2015-07-09T15_52_04-Measurement1/Images/Index.idx.xml
+experiment_44	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 44__2016-02-16T16_07_20-Measurement1/Images/Index.idx.xml
+experiment_45	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 45__2016-02-16T17_20_42-Measurement1/Images/Index.idx.xml
+experiment_46	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp46__2016-03-03T12_24_01-Measurement1/Images/Index.idx.xml
+experiment_47	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-16 HipSci Exp 47__2016-02-24T12_13_40-Measurement1/Images/Index.idx.xml
+experiment_48	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-02-24 HipSci Exp 48__2016-02-24T12_58_55-Measurement1/Images/Index.idx.xml
+experiment_49	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03_Hipsci_assay_Exp49__2016-03-03T13_14_51-Measurement1/Images/Index.idx.xml
+experiment_5	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2014-05-28_Experiment 5 HipSci_OC__2014-05-28T15_07_33-Measurement1/Images/Index.idx.xml
+experiment_50	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp50__2016-03-03T14_09_29-Measurement1/Images/Index.idx.xml
+experiment_51	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp51__2016-03-03T15_14_48-Measurement1/Images/Index.idx.xml
+experiment_52	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp52__2016-03-03T15_59_09-Measurement1/Images/Index.idx.xml
+experiment_53	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-03 HipSci Exp53__2016-03-03T16_41_19-Measurement1/Images/Index.idx.xml
+experiment_54	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-10 HipSci Exp54__2016-03-10T15_20_30-Measurement1/Images/Index.idx.xml
+experiment_55	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-10 HipSci Exp55__2016-03-10T16_09_19-Measurement1/Images/Index.idx.xml
+experiment_56	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-15 HipSci Exp56__2016-03-15T13_12_31-Measurement1/Images/Index.idx.xml
+experiment_57	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-17 HipSci Exp57__2016-03-17T10_37_40-Measurement1/Images/Index.idx.xml
+experiment_58	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-17 HipSci Exp58__2016-03-17T11_44_22-Measurement1/Images/Index.idx.xml
+experiment_59	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-03-24 HipSci Exp59__2016-03-24T13_33_15-Measurement1/Images/Index.idx.xml
+experiment_6	/uod/idr/filesets/idr0037-vigilante-hipsci/images/Experiment 6 05062014 NM__2014-06-05T10_05_19-Measurement1/Images/Index.idx.xml
+experiment_60	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-06-03 HipSci Exp60__2016-06-03T13_21_24-Measurement1/Images/Index.idx.xml
+experiment_61	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-06-03 HipSci Exp61__2016-06-03T14_17_55-Measurement1/Images/Index.idx.xml
+experiment_62	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-08 HipSci Exp 62__2016-09-08T12_25_29-Measurement1/Images/Index.idx.xml
+experiment_63	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-08 HipSci Exp 63__2016-09-13T12_36_37-Measurement1/Images/Index.idx.xml
+experiment_64	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-20 HipSci Exp 64__2016-09-20T10_53_55-Measurement1/Images/Index.idx.xml
+experiment_65	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-09-23 HipSci Exp 65__2016-09-23T12_51_26-Measurement1/Images/Index.idx.xml
+experiment_66	/uod/idr/filesets/idr0037-vigilante-hipsci/images/2016-10-03 HipSci Exp 66__2016-10-03T11_12_03-Measurement1/Images/Index.idx.xml
+experiment_7a	/uod/idr/filesets/idr0037-vigilante-hipsci/images/HipSci Experiment 7 Plate 1 24072014__2014-07-24T09_56_40-Measurement1/Images/Index.idx.xml
+experiment_7b	/uod/idr/filesets/idr0037-vigilante-hipsci/images/HipSci Experiment 7 Plate 2 24072014__2014-07-24T11_10_20-Measurement1/Images/Index.idx.xml
+experiment_8	/uod/idr/filesets/idr0034-kilpinen-hipsci/20170421-original/Oli/Experiment 8 Plate 2_Bob funp3 qimz1 zisa3_OC_06-08-2014__2014-08-06T10_45_42-Measurement1/Images/Index.idx.xml
+experiment_9	/uod/idr/filesets/idr0037-vigilante-hipsci/images/Experiment 9 Plate 1_Bob hikj1 qanu2 huls1 vopm2_22-08-2014_OC__2014-08-26T13_30_05-Measurement1/Images/Index.idx.xml

--- a/screenA/readers.txt
+++ b/screenA/readers.txt
@@ -1,0 +1,1 @@
+loci.formats.in.OperettaReader


### PR DESCRIPTION
Various configuration improvements to speed up the import of idr0037, some of them are related to the ongoing import work of OMERO 5.4.8

- point the `plates.tsv` to the master XML file to speed up the detection time
- make `bulk.yml` standalone
- skip all steps (minmax, thumbnails)
- use new `--parallel-upload` options - see https://github.com/openmicroscopy/openmicroscopy/pull/5828